### PR TITLE
Switch to get_env instead of fetch_env and

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -10,11 +10,11 @@ use Mix.Config
 
 # You can configure for your application as:
 #
-#     config :gh_webhook_plug, key: :value
+#     config :gh_webhook_plug, secret: :value
 #
 # And access this configuration in your application as:
 #
-#     Application.get_env(:gh_webhook_plug, :key)
+#     Application.get_env(:gh_webhook_plug, :secret)
 #
 # Or configure a 3rd-party app:
 #

--- a/lib/gh_webhook_plug.ex
+++ b/lib/gh_webhook_plug.ex
@@ -38,8 +38,8 @@ defmodule GhWebhookPlug do
   end
 
   defp get_secret do
-    case(System.get_env("GH_WEBHOOK_SECRET") || Application.fetch_env(:gh_webhook_plug, :secret)) do
-      :error ->
+    case(System.get_env("GH_WEBHOOK_SECRET") || Application.get_env(:gh_webhook_plug, :secret)) do
+      nil ->
         Logger.warn "Github webhook secret is not configured."
         ""
       secret -> secret


### PR DESCRIPTION
This was not working with an application config.  Using `fetch_env` worked properly on the error, but on success it returned `{:ok, secret}` instead of just the secret.  Not sure if that was an elixir language change.  Switch to using `get_env` so that it returns the secret or nil, and then instead of matching on `:error` matched on `nil`.  Test case added to show this.
